### PR TITLE
Fix #36: keep driver_version as string when it has patch version (e.g…

### DIFF
--- a/nvidia/gpu.go
+++ b/nvidia/gpu.go
@@ -29,6 +29,17 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
+// stringOnlyFields are CSV columns that must always be stored as strings (never parsed as float).
+// e.g. driver_version can be "460.91.03" (patch version), which ParseFloat would reject.
+var stringOnlyFields = map[string]bool{
+	"driver_version": true,
+	"name":           true,
+	"gpu_bus_id":     true,
+	"gpu_uuid":       true,
+	"process_name":   true,
+	"gpu_name":       true,
+}
+
 //GPUUtilization provides interface to utilization metrics and state of GPU.
 type GPUUtilization interface {
 	command(env string) *exec.Cmd
@@ -112,6 +123,11 @@ func (g Utilization) run(cmd *exec.Cmd, gpuCount int, query string, action Actio
 		}
 		for i := 0; i < len(record) && i < len(headers); i++ {
 			rawValue := record[i]
+			headerName := strings.TrimSpace(headers[i])
+			if stringOnlyFields[headerName] {
+				event.Put(headers[i], rawValue)
+				continue
+			}
 			iValue, err := strconv.ParseFloat(record[i], 64)
 			if err == nil {
 				event.Put(headers[i], iValue)

--- a/nvidia/gpu_test.go
+++ b/nvidia/gpu_test.go
@@ -18,7 +18,10 @@
 package nvidia
 
 import (
+	"bufio"
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -95,5 +98,37 @@ func Test_Event_Contains_Type_Field(t *testing.T) {
 		if o["type"] != "nvidiagpubeat" {
 			t.Errorf("event does not contain 'type' field equal to 'nvidiagpubeat'")
 		}
+	}
+}
+
+// stringReaderMock is an Action that reads from a fixed string (for testing driver_version etc.).
+type stringReaderMock struct{ content string }
+
+func (m stringReaderMock) start(cmd *exec.Cmd) *bufio.Reader {
+	return bufio.NewReader(strings.NewReader(m.content))
+}
+
+// Test_DriverVersion_WithPatchVersion verifies driver_version with patch (e.g. 460.91.03) is stored as string (Fix #36).
+func Test_DriverVersion_WithPatchVersion(t *testing.T) {
+	util := newUtilization()
+	query := "--query-gpu=name,driver_version,count"
+	// Header line (skipped: contains gpu_uuid); then one data line with driver_version 460.91.03
+	csvContent := "name, driver_version, count, gpu_uuid\nTesla P100, 460.91.03, 1\n"
+	mock := stringReaderMock{content: csvContent}
+	cmd := util.command("prod", query)
+	events, err := util.run(cmd, 1, query, mock)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if len(events) != 1 || events[0] == nil {
+		t.Fatal("expected one event")
+	}
+	ev := events[0]
+	drv, ok := ev["driver_version"]
+	if !ok {
+		t.Fatal("event missing driver_version")
+	}
+	if s, ok := drv.(string); !ok || s != "460.91.03" {
+		t.Errorf("driver_version should be string \"460.91.03\", got %T %v", drv, drv)
 	}
 }


### PR DESCRIPTION
**Summary of fix**
Fixes #36. When driver_version from nvidia-smi has a patch segment (e.g. 460.91.03), the beat used to parse it as a float and failed with number_format_exception: multiple points. This change keeps driver_version and other string-only CSV columns as strings so patch versions are handled correctly.

Changes made

- nvidia/gpu.go

Introduced a stringOnlyFields set for CSV columns that must never be parsed as float: driver_version, name, gpu_bus_id, gpu_uuid, process_name, gpu_name.
In the CSV parsing loop, values for these columns are stored as strings; only other columns are parsed with strconv.ParseFloat (with string fallback on error).

- nvidia/gpu_test.go

Added Test_DriverVersion_WithPatchVersion: uses a mock that returns CSV with driver_version=460.91.03 and asserts the event stores it as a string.

No change to config or to the default query; behavior is backward compatible.

**Request to eBay maintainer**
Please review and merge this PR when convenient. Thank you.