### PR TITLE
Fix #34: use fields.yml for export template so properties and @timest…

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ export PATH=$PATH:.
 
 localnvidiasmi executable built for macOS and is a mock GPU event generator that supports events for --query-compute-apps and --query-gpu. The executable is generated using nvidiasmilocal/localnvidiasmi.go file.
 
+### Export index template
+To export the index template (e.g. for loading into Elasticsearch), run with the config file so the correct field mappings are used (including `@timestamp` as `date`):
+
+```bash
+./nvidiagpubeat -c nvidiagpubeat.yml export template
+```
+
+The config sets `setup.template.fields` to `_meta/fields.yml`, so the exported template includes the proper `properties` (see issue #34, #15).
 
 ### Sample event
 The file nvidiagpubeat.yml defines the beat `nvidiagpubeat` with multiple options for `query`. For example `query: "--query-gpu=` will provide information about GPU and `query: "--query-compute-apps=` will list currently active compute processes.

--- a/_meta/fields.yml
+++ b/_meta/fields.yml
@@ -18,12 +18,35 @@
 # limitations under the License.
 # ************************************************************************/
 
+# Fields used to generate the index template (see issue #34, #15).
+# Export with: ./nvidiagpubeat -c nvidiagpubeat.yml export template
 - key: nvidiagpubeat
   title: nvidiagpubeat
-  description:
+  description: >
+    NVIDIA GPU metrics collected via nvidia-smi.
   fields:
+    - name: "@timestamp"
+      type: date
+      required: true
+      description: >
+        Timestamp when the event was generated.
+    - name: beat
+      type: group
+      description: >
+        Beat metadata.
+      fields:
+        - name: hostname
+          type: keyword
+        - name: name
+          type: keyword
+        - name: version
+          type: keyword
     - name: counter
       type: long
       required: true
       description: >
         PLEASE UPDATE DOCUMENTATION
+    - name: type
+      type: keyword
+      description: >
+        Event type.

--- a/nvidiagpubeat.yml
+++ b/nvidiagpubeat.yml
@@ -36,6 +36,10 @@ nvidiagpubeat:
   # env can be test or production. test is for test purposes to evaluate funcationality of this beat. Switch to production
   # when you want to run this beat on a Nvidia GPU machine with SMI driver installed.
 
+#================================ Template (export template / setup) ===========
+# Path to fields.yml so "export template" and "setup" use correct mappings (Fix #34, #15).
+setup.template.fields: "_meta/fields.yml"
+
 #================================ General =====================================
 
 # The name of the shipper that publishes the network data. It can be used to group


### PR DESCRIPTION
Summary of fix
Fixes #34. The export template output previously had empty "properties": {}, which led to @timestamp being mapped as a string 1. This change wires the beat to the repo’s fields definition so the exported template has the right mappings.

Changes made

- \meta/fields.yml – Define fields used for template generation: @timestamp (type date), beat (group: hostname, name, version as keyword), type (keyword), and existing counter (long).
- nvidiagpubeat.yml – Set setup.template.fields: "_meta/fields.yml" so export template and setup use this file instead of the empty embedded asset.
- README.md – Add an “Export index template” section: run ./nvidiagpubeat -c nvidiagpubeat.yml export template and note that the config points at _meta/fields.yml for correct mappings.

Verification
Run from repo root:
`
./nvidiagpubeat -c nvidiagpubeat.yml export template
{
  "index_patterns": [
    "nvidiagpubeat-6.5.5-*"
  ],
  "mappings": {
    "doc": {
      "_meta": {
        "version": "6.5.5"
      },
      "date_detection": false,
      "dynamic_templates": [
        {
          "strings_as_keyword": {
            "mapping": {
              "ignore_above": 1024,
              "type": "keyword"
            },
            "match_mapping_type": "string"
          }
        }
      ],
      "properties": {
        "@timestamp": {
          "type": "date"
        },
        "beat": {
          "properties": {
            "hostname": {
              "ignore_above": 1024,
              "type": "keyword"
            },
            "name": {
              "ignore_above": 1024,
              "type": "keyword"
            },
            "version": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        },
        "counter": {
          "type": "long"
        },
        "type": {
          "ignore_above": 1024,
          "type": "keyword"
        }
      }
    }
  },
  "order": 1,
  "settings": {
    "index": {
      "mapping": {
        "total_fields": {
          "limit": 10000
        }
      },
      "number_of_routing_shards": 30,
      "refresh_interval": "5s"
    }
  }
}

`

The JSON now has non-empty mappings.doc.properties with @timestamp as date, plus beat, counter, type.

**Request to eBay maintainer**
Please review and merge this PR when convenient. Thank you.
