### PR TITLE
Fix #32: keep driver_version as string (e.g. 460.32.03) to avoid ES f…

### DIFF
--- a/nvidia/gpu.go
+++ b/nvidia/gpu.go
@@ -29,6 +29,17 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
+// stringOnlyFields are CSV columns that must always be stored as strings (never parsed as float).
+// e.g. driver_version can be "460.32.03" (two dots), which ParseFloat would reject (#32).
+var stringOnlyFields = map[string]bool{
+	"driver_version": true,
+	"name":           true,
+	"gpu_bus_id":     true,
+	"gpu_uuid":       true,
+	"process_name":   true,
+	"gpu_name":       true,
+}
+
 //GPUUtilization provides interface to utilization metrics and state of GPU.
 type GPUUtilization interface {
 	command(env string) *exec.Cmd
@@ -112,6 +123,11 @@ func (g Utilization) run(cmd *exec.Cmd, gpuCount int, query string, action Actio
 		}
 		for i := 0; i < len(record) && i < len(headers); i++ {
 			rawValue := record[i]
+			headerName := strings.TrimSpace(headers[i])
+			if stringOnlyFields[headerName] {
+				event.Put(headers[i], rawValue)
+				continue
+			}
 			iValue, err := strconv.ParseFloat(record[i], 64)
 			if err == nil {
 				event.Put(headers[i], iValue)

--- a/nvidia/gpu_test.go
+++ b/nvidia/gpu_test.go
@@ -18,7 +18,10 @@
 package nvidia
 
 import (
+	"bufio"
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -95,5 +98,36 @@ func Test_Event_Contains_Type_Field(t *testing.T) {
 		if o["type"] != "nvidiagpubeat" {
 			t.Errorf("event does not contain 'type' field equal to 'nvidiagpubeat'")
 		}
+	}
+}
+
+// stringReaderMock is an Action that reads from a fixed string (for testing driver_version etc.).
+type stringReaderMock struct{ content string }
+
+func (m stringReaderMock) start(cmd *exec.Cmd) *bufio.Reader {
+	return bufio.NewReader(strings.NewReader(m.content))
+}
+
+// Test_DriverVersion_WithTwoDots verifies driver_version e.g. 460.32.03 is stored as string (Fix #32).
+func Test_DriverVersion_WithTwoDots(t *testing.T) {
+	util := newUtilization()
+	query := "--query-gpu=name,driver_version,count"
+	csvContent := "name, driver_version, count, gpu_uuid\nGeForce RTX 3090, 460.32.03, 2\n"
+	mock := stringReaderMock{content: csvContent}
+	cmd := util.command("prod", query)
+	events, err := util.run(cmd, 1, query, mock)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if len(events) != 1 || events[0] == nil {
+		t.Fatal("expected one event")
+	}
+	ev := events[0]
+	drv, ok := ev["driver_version"]
+	if !ok {
+		t.Fatal("event missing driver_version")
+	}
+	if s, ok := drv.(string); !ok || s != "460.32.03" {
+		t.Errorf("driver_version should be string \"460.32.03\", got %T %v", drv, drv)
 	}
 }


### PR DESCRIPTION
Summary of fix

Fixes #32. With driver versions like 460.32.03 (two dots), the beat could send driver_version in a way that led Elasticsearch to map it as float. Indexing then failed with mapper_parsing_exception: failed to parse field [driver_version] of type [float] and number_format_exception: multiple points. This change keeps driver_version and other string-only CSV columns as strings so ES no longer tries to parse them as float.

Changes made

- nvidia/gpu.go
Added a stringOnlyFields set for CSV columns that must never be parsed as float: driver_version, name, gpu_bus_id, gpu_uuid, process_name, gpu_name.
In the CSV parsing loop, values for these columns are stored as strings; only other columns are parsed with strconv.ParseFloat (with string fallback on error).

- nvidia/gpu_test.go
Added Test_DriverVersion_WithTwoDots: uses a mock that returns CSV with driver_version=460.32.03 and asserts the event stores it as a string.
- No config or default query changes; behavior is backward compatible.

**Request to eBay maintainer**
Please review and merge this PR when convenient. Thank you.