### PR TITLE
Fix #29: avoid index out of range when --query-compute-apps returns m…

### DIFF
--- a/nvidia/gpu.go
+++ b/nvidia/gpu.go
@@ -64,11 +64,13 @@ func (g Utilization) command(env string, query string) *exec.Cmd {
 
 //Run the nvidiasmi command to collect GPU metrics
 //Parse output and return events.
+//For --query-gpu there is one row per GPU; for --query-compute-apps there is one row per process
+//(possibly more than gpuCount), so we append events instead of using a fixed-size slice (#29).
 func (g Utilization) run(cmd *exec.Cmd, gpuCount int, query string, action Action) ([]common.MapStr, error) {
 	logp.Info("Running command %s for query:  %s  with gpuCount %d", cmd, query, gpuCount)
 	reader := action.start(cmd)
 	gpuIndex := 0
-	events := make([]common.MapStr, gpuCount, 2*gpuCount)
+	events := make([]common.MapStr, 0, gpuCount*2)
 
 	for {
 		line, err := reader.ReadString('\n')
@@ -119,7 +121,7 @@ func (g Utilization) run(cmd *exec.Cmd, gpuCount int, query string, action Actio
 				event.Put(headers[i], rawValue)
 			}
 		}
-		events[gpuIndex] = event
+		events = append(events, event)
 		gpuIndex++
 	}
 	cmd.Wait()


### PR DESCRIPTION
Fixes #29. When using --query-compute-apps, nvidia-smi returns one CSV row per process (not per GPU). If there are more processes than GPUs (e.g. several processes on one card), the beat panicked with index out of range [4] with length 4 because events were allocated as events[gpuCount] and indexed by row number. This change builds the events slice with append so the number of events matches the number of rows (one event per process).

Changes made

- nvidia/gpu.go
In run(), replaced fixed-size events := make([]common.MapStr, gpuCount, 2*gpuCount) with events := make([]common.MapStr, 0, gpuCount*2) and events = append(events, event) instead of events[gpuIndex] = event.
- Added a short comment that --query-gpu is one row per GPU and --query-compute-apps is one row per process.

**Request to eBay maintainer**
Please review and merge when convenient. Thank you.